### PR TITLE
Add browser scraping command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ uv pip install -e .
 # List Suno songs
 python -m suno_to_youtube.cli list-suno --api-key <YOUR_SUNO_TOKEN>
 
+# Scrape songs from a public Suno profile using a browser
+python -m suno_to_youtube.cli scrape-suno https://suno.com/@wavesoflove
+
 # List YouTube videos from a channel
 python -m suno_to_youtube.cli list-youtube <CHANNEL_ID> --api-key <YOUR_YT_KEY>
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
     "requests",
     "google-api-python-client",
+    "playwright",
 ]
 
 [build-system]

--- a/src/suno_to_youtube/browser.py
+++ b/src/suno_to_youtube/browser.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+# Importing Playwright inside the function so that the module can be imported
+# even if Playwright is not installed. This avoids ImportError when running
+# commands that do not require the browser.
+
+@dataclass
+class ScrapedSong:
+    """Simple representation of a song scraped from a Suno profile."""
+
+    title: str
+    url: str
+
+
+def scrape_songs(profile_url: str) -> Iterable[ScrapedSong]:
+    """Open a browser, scroll the page and return the discovered songs."""
+    from playwright.sync_api import sync_playwright
+
+    songs: list[ScrapedSong] = []
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(profile_url)
+
+        # Scroll down until the page height no longer changes
+        prev_height = 0
+        while True:
+            page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
+            page.wait_for_timeout(1000)
+            height = page.evaluate("document.body.scrollHeight")
+            if height == prev_height:
+                break
+            prev_height = height
+
+        # Extract song titles and URLs. The selectors may need to be updated if
+        # Suno changes their markup.
+        anchors = page.query_selector_all("a[href*='/song/']")
+        for a in anchors:
+            href = a.get_attribute("href") or ""
+            title = a.inner_text().strip()
+            if href and title:
+                songs.append(ScrapedSong(title=title, url=href))
+
+        browser.close()
+    return songs

--- a/src/suno_to_youtube/cli.py
+++ b/src/suno_to_youtube/cli.py
@@ -7,6 +7,7 @@ from typing import Iterable
 from .database import Database, Song
 from .suno_api import list_public_songs
 from .youtube_api import list_channel_videos
+from .browser import scrape_songs, ScrapedSong
 
 
 def print_songs(songs: Iterable[Song]) -> None:
@@ -34,6 +35,18 @@ def cmd_list_youtube(args: argparse.Namespace) -> None:
     db.close()
 
 
+def cmd_scrape_suno(args: argparse.Namespace) -> None:
+    """Scrape songs from a public Suno profile using a browser."""
+    db = Database()
+    scraped = scrape_songs(args.url)
+    for item in scraped:
+        # use the song URL as platform_id to ensure uniqueness
+        song = Song(platform="suno", platform_id=item.url, title=item.title)
+        db.add_song(song)
+    print_songs(db.list_songs(platform="suno"))
+    db.close()
+
+
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
@@ -46,6 +59,10 @@ def main(argv: list[str] | None = None) -> None:
     yt_cmd.add_argument("channel_id", help="YouTube channel ID")
     yt_cmd.add_argument("--api-key", help="YouTube API key")
     yt_cmd.set_defaults(func=cmd_list_youtube)
+
+    scrape_cmd = sub.add_parser("scrape-suno", help="Scrape songs from a Suno profile")
+    scrape_cmd.add_argument("url", help="Profile URL, e.g. https://suno.com/@user")
+    scrape_cmd.set_defaults(func=cmd_scrape_suno)
 
     args = parser.parse_args(argv)
     args.func(args)


### PR DESCRIPTION
## Summary
- implement Playwright-based scraper to read songs from a Suno profile
- expose new `scrape-suno` subcommand in CLI
- document scraping command usage
- declare Playwright dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407355b6dc832aa7b8341f5829b902