### PR TITLE
Add screenshots for Suno scraping loops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 suno_to_youtube.db
+screenshots/


### PR DESCRIPTION
## Summary
- store screenshots for each scraping pass
- ignore generated screenshots
- document possible improvements for the scrolling loop

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407b1a8eec832aa5fa954f57ee729e