### PR TITLE
Increase scrape wait delay to 5s

### DIFF
--- a/src/suno_to_youtube/browser.py
+++ b/src/suno_to_youtube/browser.py
@@ -70,7 +70,9 @@ def scrape_songs(profile_url: str) -> Iterable[ScrapedSong]:
             # If the height and song count remain the same, no new songs were
             # loaded and we are done.
             page.keyboard.press("PageDown")
-            page.wait_for_timeout(1000)
+            # Wait for the newly scrolled content to load. A longer delay
+            # reduces the chance of missing songs on slower connections.
+            page.wait_for_timeout(5000)
             height = page.evaluate("document.body.scrollHeight")
             if height == prev_height and len(songs) == prev_count:
                 break


### PR DESCRIPTION
## Summary
- extend the page wait timeout in `scrape_songs` to 5 seconds
- add a clarifying comment about the longer delay

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407d810d30832a82bccf67f0dd802a