### PR TITLE
Add VS Code tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,58 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Install dependencies",
+            "type": "shell",
+            "command": "uv",
+            "args": ["pip", "install", "-e", "."],
+            "group": "build"
+        },
+        {
+            "label": "List Suno Songs",
+            "type": "shell",
+            "command": "python",
+            "args": ["-m", "suno_to_youtube.cli", "list-suno", "--api-key", "${input:sunoApiKey}"],
+            "problemMatcher": [],
+            "presentation": { "reveal": "always" }
+        },
+        {
+            "label": "List YouTube Videos",
+            "type": "shell",
+            "command": "python",
+            "args": ["-m", "suno_to_youtube.cli", "list-youtube", "${input:channelId}", "--api-key", "${input:youtubeApiKey}"],
+            "problemMatcher": [],
+            "presentation": { "reveal": "always" }
+        },
+        {
+            "label": "Scrape Suno Profile",
+            "type": "shell",
+            "command": "python",
+            "args": ["-m", "suno_to_youtube.cli", "scrape-suno", "${input:sunoProfileUrl}"],
+            "problemMatcher": [],
+            "presentation": { "reveal": "always" }
+        }
+    ],
+    "inputs": [
+        {
+            "id": "sunoApiKey",
+            "type": "promptString",
+            "description": "Suno API key"
+        },
+        {
+            "id": "youtubeApiKey",
+            "type": "promptString",
+            "description": "YouTube API key"
+        },
+        {
+            "id": "channelId",
+            "type": "promptString",
+            "description": "YouTube channel ID"
+        },
+        {
+            "id": "sunoProfileUrl",
+            "type": "promptString",
+            "description": "URL to Suno profile"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -32,3 +32,16 @@ python -m suno_to_youtube.cli list-youtube <CHANNEL_ID> --api-key <YOUR_YT_KEY>
 ```
 
 The commands store the song details in `suno_to_youtube.db`.
+
+## VS Code Tasks
+
+A set of VS Code tasks is provided in `.vscode/tasks.json` to simplify running
+common commands. Use **Tasks: Run Task** from the command palette and select
+one of the following:
+
+- **Install dependencies** – install the project in editable mode using `uv`.
+- **List Suno Songs** – list all songs using the Suno API.
+- **List YouTube Videos** – list public videos from a channel.
+- **Scrape Suno Profile** – scrape songs from a public profile in a browser.
+
+The tasks prompt for API keys or other values when needed.


### PR DESCRIPTION
## Summary
- add VS Code tasks for common commands
- document how to use the tasks

## Testing
- `pip install -e .` *(fails: Could not install build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6840912efbe8832ab6dddbff7a1cf398