### PR TITLE
Add VS Code launch configuration for tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,13 @@
                 "${input:sunoApiKey}"
             ],
             "console": "integratedTerminal"
+        },
+        {
+            "name": "Run Tests",
+            "type": "python",
+            "request": "launch",
+            "module": "pytest",
+            "console": "integratedTerminal"
         }
     ],
     "inputs": [


### PR DESCRIPTION
## Summary
- enable running pytest directly from VS Code by adding a new launch config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840969d7594832a821a7b65e6221f7a