### PR TITLE
Improve browser scroll

### DIFF
--- a/src/suno_to_youtube/browser.py
+++ b/src/suno_to_youtube/browser.py
@@ -52,8 +52,8 @@ class _Scraper:
                 self.songs[href] = ScrapedSong(title=title, url=href)
 
     def _scroll_and_wait(self, page):
-        page.keyboard.press("PageDown")
-        page.wait_for_timeout(5000)
+        page.evaluate("window.scrollBy(0, document.body.scrollHeight)")
+        page.wait_for_load_state("networkidle")
         return page.evaluate("document.body.scrollHeight")
 
     # --- main entry ----------------------------------------------------


### PR DESCRIPTION
## Summary
- enhance `_scroll_and_wait` so it scrolls further
- wait for the page to be idle after scrolling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68409cd295e0832aa3274e1dfaa35c2a