### PR TITLE
Add process timing context manager

### DIFF
--- a/src/suno_to_youtube/cli.py
+++ b/src/suno_to_youtube/cli.py
@@ -8,6 +8,7 @@ from .database import Database, Song
 from .suno_api import list_public_songs
 from .youtube_api import list_channel_videos
 from .browser import scrape_songs, ScrapedSong
+from .timer import process_clock
 
 
 def print_songs(songs: Iterable[Song]) -> None:
@@ -16,35 +17,38 @@ def print_songs(songs: Iterable[Song]) -> None:
 
 
 def cmd_list_suno(args: argparse.Namespace) -> None:
-    db = Database()
-    songs = list_public_songs(api_key=args.api_key)
-    for suno_song in songs:
-        song = Song(platform="suno", platform_id=suno_song.id, title=suno_song.title)
-        db.add_song(song)
-    print_songs(db.list_songs(platform="suno"))
-    db.close()
+    with process_clock("list-suno"):
+        db = Database()
+        songs = list_public_songs(api_key=args.api_key)
+        for suno_song in songs:
+            song = Song(platform="suno", platform_id=suno_song.id, title=suno_song.title)
+            db.add_song(song)
+        print_songs(db.list_songs(platform="suno"))
+        db.close()
 
 
 def cmd_list_youtube(args: argparse.Namespace) -> None:
-    db = Database()
-    videos = list_channel_videos(args.channel_id, api_key=args.api_key)
-    for video in videos:
-        song = Song(platform="youtube", platform_id=video.id, title=video.title)
-        db.add_song(song)
-    print_songs(db.list_songs(platform="youtube"))
-    db.close()
+    with process_clock("list-youtube"):
+        db = Database()
+        videos = list_channel_videos(args.channel_id, api_key=args.api_key)
+        for video in videos:
+            song = Song(platform="youtube", platform_id=video.id, title=video.title)
+            db.add_song(song)
+        print_songs(db.list_songs(platform="youtube"))
+        db.close()
 
 
 def cmd_scrape_suno(args: argparse.Namespace) -> None:
     """Scrape songs from a public Suno profile using a browser."""
-    db = Database()
-    scraped = scrape_songs(args.url)
-    for item in scraped:
-        # use the song URL as platform_id to ensure uniqueness
-        song = Song(platform="suno", platform_id=item.url, title=item.title)
-        db.add_song(song)
-    print_songs(db.list_songs(platform="suno"))
-    db.close()
+    with process_clock("scrape-suno"):
+        db = Database()
+        scraped = scrape_songs(args.url)
+        for item in scraped:
+            # use the song URL as platform_id to ensure uniqueness
+            song = Song(platform="suno", platform_id=item.url, title=item.title)
+            db.add_song(song)
+        print_songs(db.list_songs(platform="suno"))
+        db.close()
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/src/suno_to_youtube/timer.py
+++ b/src/suno_to_youtube/timer.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime
+
+
+@contextmanager
+def process_clock(name: str | None = None):
+    """Context manager to print start and end timestamps."""
+    label = name or "process"
+    start = datetime.now()
+    print(f"{label} started at {start.isoformat(timespec='seconds')}")
+    try:
+        yield
+    finally:
+        end = datetime.now()
+        print(f"{label} ended at {end.isoformat(timespec='seconds')} (duration {end - start})")
+


### PR DESCRIPTION
## Summary
- add a `process_clock` context manager for timing
- print start and end times for each CLI command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f9c7c7dec832a904ceef6ccc4c65d